### PR TITLE
'this' keyword can be tricky.

### DIFF
--- a/oop/this_keyword.js
+++ b/oop/this_keyword.js
@@ -1,10 +1,32 @@
-var obj = {
-  fn : function(a, b) {
-    console.log(this); // this is bound to the object
-  }
+function fn () {
+  console.log(this);
 }
 
-obj.fn(1, 2);
+fn();
+// Prints Global Object
+// Or 'undefined' in "strict mode". :O
+
+var obj = {
+  fn : function(a, b) {
+    console.log(this);
+  }
+}
+ 		 
+ obj.fn(1, 2);
+// Prints obj, cool
+
+var objFn = obj.fn;
+objFn(1 , 2);
+// Prints Global Object, weird.
+
+obj.fn = fn;
+
+obj.fn();
+// Prints obj, crazy!
+
+// Reason: JavaScript eval 'this' keyword using dynamic scoping. (https://en.wikipedia.org/wiki/Scope_(computer_science)#Lexical_scope_vs._dynamic_scope)
+// The rule above works just for classic functions like 'fn'. Arrow functions is a bit different.
+
 
 var fun = function(one, two) {
   console.log(one, two);


### PR DESCRIPTION
A palavra 'this' em linguagens OOP está ligada à instância, porém no JavaScript está ligada ao contexto de execução.